### PR TITLE
feat(packages): add swiftlint binary

### DIFF
--- a/packages/swiftlint/package.yaml
+++ b/packages/swiftlint/package.yaml
@@ -1,0 +1,23 @@
+---
+name: swiftlint
+description: A tool to enforce Swift style and conventions.
+homepage: https://github.com/realm/SwiftLint
+licenses:
+  - MIT
+languages:
+  - Swift
+categories:
+  - Linter
+
+source:
+  id: pkg:github/realm/SwiftLint@0.54.0
+  asset:
+    - target: linux_x64_gnu
+      file: swiftlint_linux.zip
+      bin: swiftlint_linux/swiftlint
+    - target: darwin
+      file: SwiftLintBinary-macos.artifactbundle.zip
+      bin: SwiftLintBinary.artifactbundle/swiftlint-0.54.0-macos/bin/swiftlint
+
+bin:
+  swiftlint: "{{source.asset.bin}}"

--- a/schemas/enums/language.json
+++ b/schemas/enums/language.json
@@ -165,6 +165,7 @@
         "Starlark",
         "Stylelint",
         "Svelte",
+        "Swift",
         "systemd",
         "SystemVerilog",
         "TOML",


### PR DESCRIPTION
## Describe your changes

Adds [SwiftLint](https://github.com/realm/SwiftLint) binary so [swift](https://www.swift.org/) developers can easily install a linter.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
